### PR TITLE
Update meson to v0.56.0

### DIFF
--- a/meson/meson.nuspec
+++ b/meson/meson.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>meson</id>
-    <version>0.55.0</version>
+    <version>0.56.0</version>
     <title>The Meson Build system</title>
     <authors>Jussi Pakkanen</authors>
     <owners>cansik</owners>

--- a/meson/tools/chocolateyInstall.ps1
+++ b/meson/tools/chocolateyInstall.ps1
@@ -12,7 +12,7 @@ $packageArgs = @{
   fileType        = "msi"
   silentArgs      = "${silentArgs}"
   validExitCodes  = @(0)
-  checksum64      = "1de449d672e7b66ee8ef646e8b06f6ce323ce671f31cba751a3e79cf3c59d3e3"
+  checksum64      = "57b949555708567b3d7f5153d51a42d5f917f8ffca9bdbd550ee220025588e40"
   checksumType64  = "sha256"
 }
 


### PR DESCRIPTION
Meson v0.56.0 was released on Oct 30th. Please see their [release notes](https://mesonbuild.com/Release-notes-for-0-56-0.html) for details.